### PR TITLE
Copy edits for typos, consistency, and flow

### DIFF
--- a/resources/assets/js/components/code-of-conduct.vue
+++ b/resources/assets/js/components/code-of-conduct.vue
@@ -13,7 +13,7 @@
                     <p>To read our reporting guidelines, please click <a href="/report">here</a></p>
                     <h3><b>1. Purpose</b></h3>
                     <hr>
-                    <p>A primary goal of Southeast PHP Conference is to be inclusive to the largest number of participants, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe, and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).</p>
+                    <p>A primary goal of the Southeast PHP Conference is to be inclusive to the largest number of participants, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe, and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).</p>
                     <p>This Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.</p>
                     <p>We invite all those who participate in Southeast PHP Conference activities to help us create safe and positive experiences for everyone.</p>
                 </div>
@@ -22,7 +22,7 @@
                     <hr>
                     <p>A supplemental goal of this Code of Conduct is to increase open source and open culture citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.</p>
                     <p>Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.</p>
-                    <p>If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, please recognize their efforts.</p>
+                    <p>If you see someone who is making an extra effort to ensure our community is welcoming and friendly, and encourages all participants to contribute to the fullest extent, please recognize their efforts.</p>
                 </div>
                 <div class="col-xs-12">
                     <h3><b>3. Expected Behavior</b></h3>
@@ -49,8 +49,8 @@
                         <li>Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.</li>
                         <li>Inappropriate photography or recording.</li>
                         <li>Inappropriate physical contact. You should have someone's consent before touching them.</li>
-                        <li>Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.</li>
-                        <li>Deliberate intimidation, stalking or following (online or in person).</li>
+                        <li>Unwelcome sexual attention. This includes sexualized comments or jokes, inappropriate touching, groping, and unwelcomed sexual advances.</li>
+                        <li>Deliberate intimidation, stalking, or following (online or in person).</li>
                         <li>Advocating for, or encouraging, any of the above behavior.</li>
                         <li>Sustained disruption of community events, including talks and presentations.</li>
                     </ul>

--- a/resources/assets/js/components/home.vue
+++ b/resources/assets/js/components/home.vue
@@ -49,7 +49,7 @@
         <h2 class="text-center dates">August, 16th - 17th, 2018</h2>
         <hr>
         <h4 class="text-center">The Modern PHP Toolkit</h4>
-        <p class="text-center">The Southeast PHP conference was formed by the organizers of the Nashville PHP Meetup who wanted to provide a conference for PHP developers in the Southeastern United States and abroad. Currently, the Southeast does not host a regional PHP conference, even though there are lots of PHP developers. The Southeast PHP conference was born to serve this community and to help connect it with the worldwide PHP community by giving regional developers a chance to connect with each other and the broader PHP community.</p>
+        <p class="text-center">The Southeast PHP Conference was formed by the organizers of the Nashville PHP Meetup who wanted to provide a conference for PHP developers in the Southeastern United States and abroad. Currently, the Southeast does not host a regional PHP conference, even though there are lots of PHP developers. The Southeast PHP Conference was born to serve this community and to help connect it with the worldwide PHP community by giving regional developers a chance to connect with each other and the broader PHP community.</p>
         <p class="text-center">We plan on bringing the best speakers in the PHP Community and a few from the JS/Python community to give talks and tutorials in a wide variety of topics relevant to PHP and its ecosystem.</p>
         <p class="text-center">While you are here in Nashville, we hope you will take in the sights of our beloved city. We have compiled a list of things to check out in Nashville while you visit (and are still adding more)!</p>
         <p class="text-center">To read more about the organizers, check out the <a href="/about/">Organizers</a> page!</p>
@@ -68,7 +68,7 @@
 
             <p class="text-center">We would love to talk to you about becoming a sponsor! We have sponsorship levels that fit every budget and we can work with you to come up with the perfect sponsorship opportunity.</p>
             <p class="text-center">If you are interested in sponsoring Southeast PHP, you can download our sponsor prospectus <a download href="/docs/southeastphp-sponsor-prospectus.pdf">here</a></p>
-            <p class="text-center">To see who is sponsoring the Southeast PHP conference, head over to our <a href="/sponsors">Sponsors</a> page!</p>
+            <p class="text-center">To see who is sponsoring the Southeast PHP Conference, head over to our <a href="/sponsors">Sponsors</a> page!</p>
           </div>
         </div>
         <hr>

--- a/resources/assets/js/components/home.vue
+++ b/resources/assets/js/components/home.vue
@@ -24,7 +24,7 @@
   .bottom-coc {
     padding-bottom: 1rem;
   }
-  
+
   .logo {
     box-shadow: 0px -1px 5px 0px rgba(0,0,0,0.75);
   }
@@ -42,17 +42,17 @@
         <h2 class="text-center dates">August, 16th - 17th, 2018</h2>
         <hr>
         <h4 class="text-center">The Modern PHP Toolkit</h4>
-        <p class="text-center">Southeast PHP was formed by the organizers of the Nashville PHP Meetup who wanted to provide a conference for PHP developers in the South Eastern United States and abroad. Currently, the Southeast does not host a regional PHP conference, even though there are lots of PHP developers. Southeast PHP was born to serve this community and to help connect it with the worldwide PHP community by giving regional developers a chance to connect with each other and the broader PHP community.</p>
+        <p class="text-center">The Southeast PHP conference was formed by the organizers of the Nashville PHP Meetup who wanted to provide a conference for PHP developers in the Southeastern United States and abroad. Currently, the Southeast does not host a regional PHP conference, even though there are lots of PHP developers. The Southeast PHP conference was born to serve this community and to help connect it with the worldwide PHP community by giving regional developers a chance to connect with each other and the broader PHP community.</p>
         <p class="text-center">We plan on bringing the best speakers in the PHP Community and a few from the JS/Python community to give talks and tutorials in a wide variety of topics relevant to PHP and its ecosystem.</p>
-        <p class="text-center">While you are here in Nashville, we hope you will take in the sights of our loved city. We have compiled a list, and are still adding more to it, of things to check out in Nashville while you visit!</p>
+        <p class="text-center">While you are here in Nashville, we hope you will take in the sights of our beloved city. We have compiled a list of things to check out in Nashville while you visit (and are still adding more)!</p>
         <p class="text-center">To read more about the organizers, check out the <a href="/about/organizers">Organizers</a> page!</p>
         <hr>
         <div class="row">
           <div class="col-xs-12">
             <h3 class="text-center">Sponsors</h3>
-            <p class="text-center">We would love to talk to you about becoming a sponsor! We have sponsorship levels that fit every budget and we can even take some time to come up with the perfect sponsorship opportunity.</p>
+            <p class="text-center">We would love to talk to you about becoming a sponsor! We have sponsorship levels that fit every budget and we can work with you to come up with the perfect sponsorship opportunity.</p>
             <p class="text-center">If you are interested in sponsoring Southeast PHP, you can download our sponsor prospectus <a download href="/docs/southeastphp-sponsor-prospectus.pdf">here</a></p>
-            <p class="text-center">To see who is sponsoring Southeast PHP, head over to our <a href="/sponsors">Sponsors</a> page!</p>
+            <p class="text-center">To see who is sponsoring the Southeast PHP conference, head over to our <a href="/sponsors">Sponsors</a> page!</p>
           </div>
         </div>
         <hr>
@@ -66,11 +66,11 @@
                 <h4 class="text-center">Venue</h4>
                 <p>We have picked the wonderful Hotel Preston as our venue this year. We picked it for a few reasons:</p>
                 <ul>
-                  <li>Closeness to airport</li>
+                  <li>Close to the airport</li>
                   <li>Low prices</li>
                   <li>Close to downtown</li>
                 </ul>
-                <p>We hope that you will use the venue as a place to learn, grow and meet new people, and we hope that you can use the venue as a spring board to downtown and check out Nashville!</p>
+                <p>We hope that you will use the venue as a place to learn, grow, and meet new people, and we hope that you can use the venue as a springboard to downtown and check out Nashville!</p>
                 <br>
                 <a href="https://hotelpreston.com"><button class="btn btn-success">The Venue</button></a>
               </div>
@@ -83,8 +83,8 @@
                 <hr>
 
                 <h4 class="text-center">Code of Conduct</h4>
-                <p><b>We take inclusion, safety, and diversity seriously.</b><br><br> We set up a Code of Conduct to make sure that every attendee feels safe and welcome at Southeast PHP Conference. </p>
-                <p class="bottom-coc">Before buying a ticket to Southeast PHP, we ask that you take a look and understand our Code of Conduct. While it is not different from any other conference, we do want everyone to be made aware of it.</p>
+                <p><b>We take inclusion, safety, and diversity seriously.</b><br><br> We set up a Code of Conduct to make sure that every attendee feels safe and welcome at the Southeast PHP Conference. </p>
+                <p class="bottom-coc">Before buying a ticket to the conference, we ask that you take a look and understand our Code of Conduct. While it is not different from any other conference, we do want everyone to be made aware of it.</p>
                 <a href="/code-of-conduct"><button class="btn btn-success">Code of Conduct</button></a>
               </div>
             </div>
@@ -96,7 +96,7 @@
                 <hr>
                 <h4 class="text-center">Diversity</h4>
                 <p>As the organizers of NashvillePHP, we want to make sure we make sure everyone has a chance to attend our conference, whether you live in Nashville or some place further away.</p>
-                <p>We have set up a way for companies to reach out to us and work with each other to provide tickets to those in under represented groups working with PHP and JS. If your company, or you yourself, want to sponsor some tickets, please let us know!</p>
+                <p>We have set up a way for companies to reach out and work with us to provide tickets to those in under-represented groups working with PHP and JS. If your company, or you as an individual, want to sponsor some tickets, please let us know!</p>
                 <a href="/diversity"><button class="btn btn-success">Diversity</button></a>
               </div>
             </div>
@@ -123,8 +123,8 @@
             </form>
 
             <h2>Call For Papers <i class="fa fa-bullhorn fa-2x" aria-hidden="true"></i> </h2>
-            <p>Our Call For Papers will start in February.</p>
-            <p>Till then, check out our <a href="#">Talk Submission</a> page for talk submission tips to help make your proposal stronger.</p>
+            <p>Our Call For Papers will open in February.</p>
+            <p>Until then, check out our <a href="#">Talk Submission</a> page for talk submission tips to help make your proposal stronger.</p>
           </div>
           <div class="col-xs-12 col-sm-12 col-md-4">
             <a class="twitter-timeline" data-width="400" data-height="500" href="https://twitter.com/SoutheastPHP?ref_src=twsrc%5Etfw">Tweets by SoutheastPHP</a>

--- a/resources/assets/js/components/sponsors.vue
+++ b/resources/assets/js/components/sponsors.vue
@@ -39,8 +39,8 @@
                 <p>We could not make this conference, and our community, possible without all of our sponsors! Sponsors help us keep the conference at the lowest price possible, while letting us work to bring you the best speakers our community has to offer. We encourage you to thank the sponsors via Twitter, or in person at the conference!</p>
                 <p>For more information about sponsoring <a href="/docs/southeastphp-sponsor-prospectus.pdf" download>download our prospectus</a></p>
 
-                <h4>Interested in shaping the diversity of the Southeast PHP conference?</h4>
-                <p>We set up a <a href="/diversity">page</a> to detail some of our efforts and ideas to help make the Southeast PHP conference as diverse as possible. If you or your company would like to help us, please let us know!</p>
+                <h4>Interested in shaping the diversity of the Southeast PHP Conference?</h4>
+                <p>We set up a <a href="/diversity">page</a> to detail some of our efforts and ideas to help make the Southeast PHP Conference as diverse as possible. If you or your company would like to help us, please let us know!</p>
 
                 <div class="col-xs-12" v-if="loading == false && (sponsorLevels.data.length == 0 || sponsors.data.length == 0)">
                     <h2>No sponsors at this time, please check back later.</h2>
@@ -76,7 +76,7 @@
             <div class="row">
                 <h1>Our Sponsor Levels</h1>
 
-                <p>If you are interested in sponsoring the Southeast PHP conference, please email us at <a href="mailto:organizers@southeastphp.com">organizers@southeastphp.com</a> and we will be more than happy to discuss potential sponsorships!</p>
+                <p>If you are interested in sponsoring the Southeast PHP Conference, please email us at <a href="mailto:organizers@southeastphp.com">organizers@southeastphp.com</a> and we will be more than happy to discuss potential sponsorships!</p>
 
                 <table class="table table-hover">
                     <thead>

--- a/resources/assets/js/components/sponsors.vue
+++ b/resources/assets/js/components/sponsors.vue
@@ -72,7 +72,7 @@
             <div class="row">
                 <h1>Our Sponsor Levels</h1>
 
-                <p>If you are interested in sponsoring Southeast PHP, please email us at <a href="mailto:organizers@southeastphp.com">organizers@southeastphp.com</a> and we will be more than happy to discuss potential sponsorships!3</p>
+                <p>If you are interested in sponsoring the Southeast PHP conference, please email us at <a href="mailto:organizers@southeastphp.com">organizers@southeastphp.com</a> and we will be more than happy to discuss potential sponsorships!</p>
 
                 <table class="table table-hover">
                     <thead>
@@ -103,7 +103,7 @@
                     <li>Laynard Sponsor</li>
                     <li>Swag Bag Sponsor</li>
                 </ul>
-            </div>w
+            </div>
         </div>
         <se-footer></se-footer>
     </div>

--- a/resources/assets/js/components/sponsors.vue
+++ b/resources/assets/js/components/sponsors.vue
@@ -31,11 +31,11 @@
         <div class="container">
             <div class="row">
                 <h1>Our Sponsors</h1>
-                <p>We could not make this conference, and our community, possible without all of our sponsors! Sponsors help us keep the conference at the lowest price possible, while letting us work to bring you the best speakers our community has to offer. We encourage you to thank the sponsors via Twitter, or in person at Southeast PHP Conference!</p>
+                <p>We could not make this conference, and our community, possible without all of our sponsors! Sponsors help us keep the conference at the lowest price possible, while letting us work to bring you the best speakers our community has to offer. We encourage you to thank the sponsors via Twitter, or in person at the conference!</p>
                 <p>For more information about sponsoring <a href="/docs/southeastphp-sponsor-prospectus.pdf" download>download our prospectus</a></p>
 
-                <h4>Interested in shaping the diversity of Southeast PHP?</h4>
-                <p>We set up a <a href="/diversity">page</a> to detail some of our efforts and ideas to help make Southeast PHP as diverse as possible. If you or your company would like to help us, please let us know!</p>
+                <h4>Interested in shaping the diversity of the Southeast PHP conference?</h4>
+                <p>We set up a <a href="/diversity">page</a> to detail some of our efforts and ideas to help make the Southeast PHP conference as diverse as possible. If you or your company would like to help us, please let us know!</p>
 
                 <div class="col-xs-12" v-if="loading == false && (sponsorLevels.data.length == 0 || sponsors.data.length == 0)">
                     <h2>No sponsors at this time, please check back later.</h2>
@@ -94,7 +94,7 @@
                 </table>
 
                 <h3>Additional Sponsorship Opportunities</h3>
-                <p>We do not want to limit the opportunities for companies and groups to sponsor Southeast PHP Conference. Below are a few suggestions, limited only by our imaginations. If you want to be involved in Southeast PHP, here are some suggestions</p>
+                <p>We do not want to limit the opportunities for companies and groups to sponsor the Southeast PHP Conference. Below are a few suggestions, limited only by our imaginations. If you want to be involved in the conference, here are some suggestions</p>
                 <ul>
                     <li>After Party Sponsor (Two sponsorships available)</li>
                     <li>Speaker Dinner Sponsor</li>


### PR DESCRIPTION
Various copy edits

- removed some stray characters
- made the conference name and case consistent ("Southeast PHP Conference")
- slight changes for flow and readability