### PR TITLE
Adds missing class to update_sponsors_table migration

### DIFF
--- a/database/migrations/2018_07_23_023258_update_sponsors_table.php
+++ b/database/migrations/2018_07_23_023258_update_sponsors_table.php
@@ -1,8 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
+use App\Models\Sponsor;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class UpdateSponsorsTable extends Migration
 {


### PR DESCRIPTION
Without this the migration failed on first run of php artisan migrate


Not sure if this is the best way to do this, TBH...but I can't think of a better way to fix it, so just lemme know if there is one and I'll hop on it